### PR TITLE
Simplifications of network + fix for unique service name

### DIFF
--- a/templates/bootstrap.g8os/actions.py
+++ b/templates/bootstrap.g8os/actions.py
@@ -99,7 +99,8 @@ def try_authorize(service, logger, netid, member, zerotier):
         # it could happend that a node get a new ip after a reboot
         node.model.data.redisAddr = zerotier_ip
         node.model.data.status = 'running'
-
+        # after reboot we also wonna call install
+        j.tools.async.wrappers.sync(node.executeAction('install'))
     except j.exceptions.NotFound:
         # create and install the node.g8os service
         node_actor = service.aysrepo.actorGet('node.g8os')

--- a/templates/node.g8os/actions.py
+++ b/templates/node.g8os/actions.py
@@ -17,28 +17,16 @@ def init(job):
 
 
 def getAddresses(job):
-    import asyncio
     service = job.service
-    try:
-        loop = asyncio.get_event_loop()
-    except:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-    futures = []
     networks = service.producers.get('network', [])
+    networkmap = {}
     for network in networks:
         job = network.getJob('getAddresses', args={'node_name': service.name})
-        futures.append(job.execute())
-
-    if futures:
-        return {i.name: j for i, j in zip(networks, loop.run_until_complete(asyncio.gather(*futures)))}
-    else:
-        return {}
+        networkmap[network.name] = j.tools.async.wrappers.sync(job.execute())
+    return networkmap
 
 
 def install(job):
-    import asyncio
-
     # at each boot recreate the complete state in the system
     service = job.service
     node = j.sal.g8os.get_node(
@@ -52,18 +40,9 @@ def install(job):
     node.ensure_persistance(poolname)
 
     job.logger.info("configure networks")
-    try:
-        loop = asyncio.get_event_loop()
-    except:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-    futures = []
     for network in service.producers.get('network', []):
         job = network.getJob('configure', args={'node_name': service.name})
-        futures.append(job.execute())
-
-    if futures:
-        loop.run_until_complete(asyncio.gather(*futures))
+        j.tools.async.wrappers.sync(job.execute())
 
 
 def monitor(job):


### PR DESCRIPTION
AYS requires unique services names g8os requires the container to have a
tag called ovs, for this reason I've added hostname as a tag aswell see
https://github.com/Jumpscale/jumpscale_core8/pull/899

Remove asyncio stuff to make service simpler, also configuring multiple networks
should probably not be done async anyway

Signed-off-by: Jo De Boeck <deboeck.jo@gmail.com>