### PR TITLE
Extend vm status:

### DIFF
--- a/templates/vm/actions.py
+++ b/templates/vm/actions.py
@@ -145,13 +145,17 @@ def install(job):
             else:
                 time.sleep(3)
         else:
+            service.model.data.status = 'error'
             raise j.exceptions.RuntimeError("Failed to start vm {}".format(service.name))
 
     service.model.data.status = 'running'
+    service.saveAll()
 
 
 def start(job):
     service = job.service
+    service.model.data.status = 'starting'
+    service.saveAll()
     j.tools.async.wrappers.sync(service.executeAction('install'))
 
 
@@ -186,6 +190,7 @@ def stop(job):
 
     service.model.data.status = 'halted'
     service.model.data.vnc = -1
+    service.saveAll()
 
 
 def pause(job):
@@ -196,6 +201,7 @@ def pause(job):
     if kvm:
         node.client.kvm.pause(kvm['uuid'])
         service.model.data.status = 'paused'
+        service.saveAll()
 
 
 def resume(job):
@@ -206,6 +212,7 @@ def resume(job):
     if kvm:
         node.client.kvm.resume(kvm['uuid'])
         service.model.data.status = 'running'
+        service.saveAll()
 
 
 def shutdown(job):
@@ -228,6 +235,8 @@ def shutdown(job):
                 time.sleep(3)
         else:
             raise j.exceptions.RuntimeError("Failed to shutdown vm {}".format(service.name))
+    
+    service.saveAll()
 
 
 def migrate(job):
@@ -267,6 +276,7 @@ def migrate(job):
 
     j.tools.async.wrappers.sync(old_vdisk_container.executeAction('stop'))
     j.tools.async.wrappers.sync(old_vdisk_container.delete())
+    service.saveAll()
 
 
 def _remove_duplicates(col):

--- a/templates/vm/schema.capnp
+++ b/templates/vm/schema.capnp
@@ -1,4 +1,4 @@
-@0xa7426da542a1e472;
+@0xabbd4793cfc91dff;
 
 struct Schema {
     node @0: Text; # pointer to the parent service
@@ -15,12 +15,14 @@ struct Schema {
     vnc @10: Int32 = -1; # the vnc port the machine is listening to
 
     enum Status{
-        error @0;
-        halted @1;
-        running @2;
-        paused @3;
-        halting @4;
-        migrating @5;
+        deploying @0;
+        error @1;
+        halted @2;
+        running @3;
+        paused @4;
+        halting @5;
+        migrating @6;
+        starting @7;
     }
 
     struct NicLink {


### PR DESCRIPTION
- Add deploying, starting to vm status.
- Make 'deploying' the default status when a vm is first created.
- Set the status to 'starting' when a halted vm is started.