### PR TITLE
Refactor Bridge service:

### DIFF
--- a/api/node/EnumBridgeStatus.go
+++ b/api/node/EnumBridgeStatus.go
@@ -3,6 +3,7 @@ package node
 type EnumBridgeStatus string
 
 const (
-	EnumBridgeStatusup   EnumBridgeStatus = "up"
-	EnumBridgeStatusdown EnumBridgeStatus = "down"
+	EnumBridgeStatusup    EnumBridgeStatus = "up"
+	EnumBridgeStatusdown  EnumBridgeStatus = "down"
+	EnumBridgeStatuserror EnumBridgeStatus = "error"
 )

--- a/templates/bridge/schema.capnp
+++ b/templates/bridge/schema.capnp
@@ -1,4 +1,4 @@
-@0x9c644375c5885f01;
+@0x8fb9cec5b1fd4b11;
 
 struct Schema {
     hwaddr @0 :Text; # Macaddress for the bridge to be created. If none, a random macaddress will be assigned
@@ -17,6 +17,7 @@ struct Schema {
     enum Status {
         up @0;
         down @1;
+        error @2;
     }
 
     struct Setting {


### PR DESCRIPTION
- Add error to status enums.
- Set status to error if creation failed on core0.
- Check if bridge exists in core0 before attempting to delete it from core0 in the delete action.